### PR TITLE
Replace <i> icons with spans

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
     <header class="sticky top-0 bg-white dark:bg-gray-900 shadow-sm z-50">
         <nav class="max-w-7xl mx-auto px-4 py-3 flex justify-between items-center">
             <a href="#" class="flex items-center" aria-label="Home">
-                <i class="fas fa-cube text-indigo-600 mr-2 text-xl" aria-hidden="true"></i>
+                <span aria-hidden="true" class="fas fa-cube text-indigo-600 mr-2 text-xl"></span>
                 <span class="text-xl font-bold text-gray-900 dark:text-gray-100">
                     ArchEng Nexus
                 </span>
@@ -54,12 +54,12 @@
                 </a>
 
                 <button id="theme-toggle" class="focus:outline-none p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition" aria-label="Toggle theme">
-                    <i class="fas fa-moon text-gray-700 dark:text-yellow-400" aria-hidden="true"></i>
+                    <span aria-hidden="true" class="fas fa-moon text-gray-700 dark:text-yellow-400"></span>
                 </button>
             </div>
 
             <button id="mobile-menu-button" class="md:hidden p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition" aria-controls="mobile-menu" aria-expanded="false" aria-label="Toggle menu">
-                <i class="fas fa-bars text-gray-700 dark:text-gray-200" aria-hidden="true"></i>
+                <span aria-hidden="true" class="fas fa-bars text-gray-700 dark:text-gray-200"></span>
             </button>
         </nav>
 
@@ -79,7 +79,7 @@
             <div class="px-4 py-3 flex justify-between items-center">
                 <span class="text-gray-700 dark:text-gray-200">Theme</span>
                 <button id="mobile-theme-toggle" class="focus:outline-none p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition" aria-label="Toggle theme">
-                    <i class="fas fa-moon text-gray-700 dark:text-yellow-400" aria-hidden="true"></i>
+                    <span aria-hidden="true" class="fas fa-moon text-gray-700 dark:text-yellow-400"></span>
                 </button>
             </div>
         </div>
@@ -113,7 +113,7 @@
                 <div class="lg:w-1/2 flex justify-center">
                     <div class="w-full max-w-md rounded-xl overflow-hidden shadow-2xl transform transition duration-300 hover:scale-[1.02]">
                         <div class="h-64 bg-gradient-to-r from-blue-500 to-purple-600 flex items-center justify-center">
-                            <i class="fas fa-building text-white text-6xl opacity-80"></i>
+                            <span aria-hidden="true" class="fas fa-building text-white text-6xl opacity-80"></span>
                         </div>
                         <div class="p-4 bg-white dark:bg-gray-900">
                             <h3 class="font-medium text-gray-900 dark:text-gray-100">
@@ -124,10 +124,10 @@
                             </p>
                             <div class="mt-3 flex justify-between text-sm text-gray-500 dark:text-gray-400">
                                 <span>
-                                    <i class="fas fa-heart text-red-500 mr-1"></i>24 likes
+                                    <span aria-hidden="true" class="fas fa-heart text-red-500 mr-1"></span>24 likes
                                 </span>
                                 <span>
-                                    <i class="fas fa-comments text-indigo-500 mr-1"></i>8 comments
+                                    <span aria-hidden="true" class="fas fa-comments text-indigo-500 mr-1"></span>8 comments
                                 </span>
                             </div>
                         </div>
@@ -150,7 +150,7 @@
                     <!-- Feature 1 -->
                     <div class="bg-gray-50 dark:bg-gray-800 rounded-xl p-6 shadow-sm hover:shadow-md transition card-hover">
                         <div class="w-12 h-12 rounded-full bg-indigo-100 dark:bg-indigo-900 flex items-center justify-center mb-4">
-                            <i class="fas fa-robot text-indigo-600 dark:text-indigo-400 text-xl"></i>
+                            <span aria-hidden="true" class="fas fa-robot text-indigo-600 dark:text-indigo-400 text-xl"></span>
                         </div>
                         <h3 class="text-xl font-semibold text-gray-900 dark:text-white mb-2">AI Automation</h3>
                         <p class="text-gray-600 dark:text-gray-300">
@@ -161,7 +161,7 @@
                     <!-- Feature 2 -->
                     <div class="bg-gray-50 dark:bg-gray-800 rounded-xl p-6 shadow-sm hover:shadow-md transition card-hover">
                         <div class="w-12 h-12 rounded-full bg-green-100 dark:bg-green-900 flex items-center justify-center mb-4">
-                            <i class="fas fa-leaf text-green-600 dark:text-green-400 text-xl"></i>
+                            <span aria-hidden="true" class="fas fa-leaf text-green-600 dark:text-green-400 text-xl"></span>
                         </div>
                         <h3 class="text-xl font-semibold text-gray-900 dark:text-white mb-2">Sustainable Materials</h3>
                         <p class="text-gray-600 dark:text-gray-300">
@@ -172,7 +172,7 @@
                     <!-- Feature 3 -->
                     <div class="bg-gray-50 dark:bg-gray-800 rounded-xl p-6 shadow-sm hover:shadow-md transition card-hover">
                         <div class="w-12 h-12 rounded-full bg-blue-100 dark:bg-blue-900 flex items-center justify-center mb-4">
-                            <i class="fas fa-users text-blue-600 dark:text-blue-400 text-xl"></i>
+                            <span aria-hidden="true" class="fas fa-users text-blue-600 dark:text-blue-400 text-xl"></span>
                         </div>
                         <h3 class="text-xl font-semibold text-gray-900 dark:text-white mb-2">Real-time Collaboration</h3>
                         <p class="text-gray-600 dark:text-gray-300">
@@ -183,7 +183,7 @@
                     <!-- Feature 4 -->
                     <div class="bg-gray-50 dark:bg-gray-800 rounded-xl p-6 shadow-sm hover:shadow-md transition card-hover">
                         <div class="w-12 h-12 rounded-full bg-purple-100 dark:bg-purple-900 flex items-center justify-center mb-4">
-                            <i class="fas fa-cube text-purple-600 dark:text-purple-400 text-xl"></i>
+                            <span aria-hidden="true" class="fas fa-cube text-purple-600 dark:text-purple-400 text-xl"></span>
                         </div>
                         <h3 class="text-xl font-semibold text-gray-900 dark:text-white mb-2">3D Modeling</h3>
                         <p class="text-gray-600 dark:text-gray-300">
@@ -194,7 +194,7 @@
                     <!-- Feature 5 -->
                     <div class="bg-gray-50 dark:bg-gray-800 rounded-xl p-6 shadow-sm hover:shadow-md transition card-hover">
                         <div class="w-12 h-12 rounded-full bg-yellow-100 dark:bg-yellow-900 flex items-center justify-center mb-4">
-                            <i class="fas fa-chart-line text-yellow-600 dark:text-yellow-400 text-xl"></i>
+                            <span aria-hidden="true" class="fas fa-chart-line text-yellow-600 dark:text-yellow-400 text-xl"></span>
                         </div>
                         <h3 class="text-xl font-semibold text-gray-900 dark:text-white mb-2">Performance Analytics</h3>
                         <p class="text-gray-600 dark:text-gray-300">
@@ -205,7 +205,7 @@
                     <!-- Feature 6 -->
                     <div class="bg-gray-50 dark:bg-gray-800 rounded-xl p-6 shadow-sm hover:shadow-md transition card-hover">
                         <div class="w-12 h-12 rounded-full bg-red-100 dark:bg-red-900 flex items-center justify-center mb-4">
-                            <i class="fas fa-mobile-alt text-red-600 dark:text-red-400 text-xl"></i>
+                            <span aria-hidden="true" class="fas fa-mobile-alt text-red-600 dark:text-red-400 text-xl"></span>
                         </div>
                         <h3 class="text-xl font-semibold text-gray-900 dark:text-white mb-2">Mobile Access</h3>
                         <p class="text-gray-600 dark:text-gray-300">
@@ -230,7 +230,7 @@
                     <!-- Material 1 -->
                     <div class="bg-white dark:bg-gray-900 rounded-lg overflow-hidden shadow-sm hover:shadow-md transition card-hover">
                         <div class="h-40 bg-gradient-to-r from-green-400 to-blue-500 flex items-center justify-center">
-                            <i class="fas fa-recycle text-white text-5xl opacity-90"></i>
+                            <span aria-hidden="true" class="fas fa-recycle text-white text-5xl opacity-90"></span>
                         </div>
                         <div class="p-4">
                             <h3 class="font-semibold text-gray-900 dark:text-white">Recycled Composites</h3>
@@ -247,7 +247,7 @@
                     <!-- Material 2 -->
                     <div class="bg-white dark:bg-gray-900 rounded-lg overflow-hidden shadow-sm hover:shadow-md transition card-hover">
                         <div class="h-40 bg-gradient-to-r from-purple-500 to-pink-500 flex items-center justify-center">
-                            <i class="fas fa-solar-panel text-white text-5xl opacity-90"></i>
+                            <span aria-hidden="true" class="fas fa-solar-panel text-white text-5xl opacity-90"></span>
                         </div>
                         <div class="p-4">
                             <h3 class="font-semibold text-gray-900 dark:text-white">Solar-Active Glass</h3>
@@ -264,7 +264,7 @@
                     <!-- Material 3 -->
                     <div class="bg-white dark:bg-gray-900 rounded-lg overflow-hidden shadow-sm hover:shadow-md transition card-hover">
                         <div class="h-40 bg-gradient-to-r from-yellow-400 to-orange-500 flex items-center justify-center">
-                            <i class="fas fa-biohazard text-white text-5xl opacity-90"></i>
+                            <span aria-hidden="true" class="fas fa-biohazard text-white text-5xl opacity-90"></span>
                         </div>
                         <div class="p-4">
                             <h3 class="font-semibold text-gray-900 dark:text-white">Bio-Based Polymers</h3>
@@ -281,7 +281,7 @@
                     <!-- Material 4 -->
                     <div class="bg-white dark:bg-gray-900 rounded-lg overflow-hidden shadow-sm hover:shadow-md transition card-hover">
                         <div class="h-40 bg-gradient-to-r from-gray-700 to-gray-900 flex items-center justify-center">
-                            <i class="fas fa-cubes text-white text-5xl opacity-90"></i>
+                            <span aria-hidden="true" class="fas fa-cubes text-white text-5xl opacity-90"></span>
                         </div>
                         <div class="p-4">
                             <h3 class="font-semibold text-gray-900 dark:text-white">Self-Healing Concrete</h3>
@@ -299,7 +299,7 @@
                 <div class="mt-12 text-center">
                     <a href="#" class="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition">
                         Browse Full Material Library
-                        <i class="fas fa-arrow-right ml-2"></i>
+                        <span aria-hidden="true" class="fas fa-arrow-right ml-2"></span>
                     </a>
                 </div>
             </div>
@@ -321,7 +321,7 @@
                             <div class="flex items-start mb-6">
                                 <div class="flex-shrink-0">
                                     <div class="flex items-center justify-center h-12 w-12 rounded-md bg-indigo-500 text-white">
-                                        <i class="fas fa-drafting-compass text-xl"></i>
+                                        <span aria-hidden="true" class="fas fa-drafting-compass text-xl"></span>
                                     </div>
                                 </div>
                                 <div class="ml-4">
@@ -335,7 +335,7 @@
                             <div class="flex items-start mb-6">
                                 <div class="flex-shrink-0">
                                     <div class="flex items-center justify-center h-12 w-12 rounded-md bg-blue-500 text-white">
-                                        <i class="fas fa-bolt text-xl"></i>
+                                        <span aria-hidden="true" class="fas fa-bolt text-xl"></span>
                                     </div>
                                 </div>
                                 <div class="ml-4">
@@ -349,7 +349,7 @@
                             <div class="flex items-start">
                                 <div class="flex-shrink-0">
                                     <div class="flex items-center justify-center h-12 w-12 rounded-md bg-green-500 text-white">
-                                        <i class="fas fa-chart-pie text-xl"></i>
+                                        <span aria-hidden="true" class="fas fa-chart-pie text-xl"></span>
                                     </div>
                                 </div>
                                 <div class="ml-4">
@@ -367,7 +367,7 @@
                             <div class="absolute -top-6 -left-6 w-full h-full bg-indigo-100 dark:bg-indigo-900 rounded-xl opacity-30"></div>
                             <div class="relative bg-white dark:bg-gray-800 rounded-xl overflow-hidden shadow-lg">
                                 <div class="h-80 bg-gradient-to-br from-blue-500 to-indigo-600 flex items-center justify-center">
-                                    <i class="fas fa-laptop-code text-white text-7xl opacity-80"></i>
+                                    <span aria-hidden="true" class="fas fa-laptop-code text-white text-7xl opacity-80"></span>
                                 </div>
                                 <div class="p-6">
                                     <h3 class="text-xl font-semibold text-gray-900 dark:text-white">All Tools. One Platform.</h3>
@@ -377,7 +377,7 @@
                                     <div class="mt-4">
                                         <a href="#" class="text-indigo-600 dark:text-indigo-400 font-medium hover:text-indigo-500 dark:hover:text-indigo-300 transition">
                                             See all tools
-                                            <i class="fas fa-arrow-right ml-1"></i>
+                                            <span aria-hidden="true" class="fas fa-arrow-right ml-1"></span>
                                         </a>
                                     </div>
                                 </div>
@@ -403,7 +403,7 @@
                     <div class="bg-white dark:bg-gray-900 rounded-xl p-6 shadow-sm hover:shadow-md transition card-hover">
                         <div class="flex items-center mb-4">
                             <div class="flex-shrink-0 h-10 w-10 rounded-full bg-indigo-100 dark:bg-indigo-900 flex items-center justify-center">
-                                <i class="fas fa-home text-indigo-600 dark:text-indigo-400"></i>
+                                <span aria-hidden="true" class="fas fa-home text-indigo-600 dark:text-indigo-400"></span>
                             </div>
                             <h3 class="ml-3 text-lg font-medium text-gray-900 dark:text-white">Residential</h3>
                         </div>
@@ -413,19 +413,19 @@
                         <ul class="space-y-2">
                             <li class="flex items-start">
                                 <div class="flex-shrink-0 h-5 w-5 text-green-500">
-                                    <i class="fas fa-check"></i>
+                                    <span aria-hidden="true" class="fas fa-check"></span>
                                 </div>
                                 <p class="ml-2 text-sm text-gray-600 dark:text-gray-300">Energy efficiency optimization</p>
                             </li>
                             <li class="flex items-start">
                                 <div class="flex-shrink-0 h-5 w-5 text-green-500">
-                                    <i class="fas fa-check"></i>
+                                    <span aria-hidden="true" class="fas fa-check"></span>
                                 </div>
                                 <p class="ml-2 text-sm text-gray-600 dark:text-gray-300">Space planning automation</p>
                             </li>
                             <li class="flex items-start">
                                 <div class="flex-shrink-0 h-5 w-5 text-green-500">
-                                    <i class="fas fa-check"></i>
+                                    <span aria-hidden="true" class="fas fa-check"></span>
                                 </div>
                                 <p class="ml-2 text-sm text-gray-600 dark:text-gray-300">Cost estimation tools</p>
                             </li>
@@ -436,7 +436,7 @@
                     <div class="bg-white dark:bg-gray-900 rounded-xl p-6 shadow-sm hover:shadow-md transition card-hover">
                         <div class="flex items-center mb-4">
                             <div class="flex-shrink-0 h-10 w-10 rounded-full bg-blue-100 dark:bg-blue-900 flex items-center justify-center">
-                                <i class="fas fa-city text-blue-600 dark:text-blue-400"></i>
+                                <span aria-hidden="true" class="fas fa-city text-blue-600 dark:text-blue-400"></span>
                             </div>
                             <h3 class="ml-3 text-lg font-medium text-gray-900 dark:text-white">Commercial</h3>
                         </div>
@@ -446,19 +446,19 @@
                         <ul class="space-y-2">
                             <li class="flex items-start">
                                 <div class="flex-shrink-0 h-5 w-5 text-green-500">
-                                    <i class="fas fa-check"></i>
+                                    <span aria-hidden="true" class="fas fa-check"></span>
                                 </div>
                                 <p class="ml-2 text-sm text-gray-600 dark:text-gray-300">LEED certification support</p>
                             </li>
                             <li class="flex items-start">
                                 <div class="flex-shrink-0 h-5 w-5 text-green-500">
-                                    <i class="fas fa-check"></i>
+                                    <span aria-hidden="true" class="fas fa-check"></span>
                                 </div>
                                 <p class="ml-2 text-sm text-gray-600 dark:text-gray-300">Foot traffic analysis</p>
                             </li>
                             <li class="flex items-start">
                                 <div class="flex-shrink-0 h-5 w-5 text-green-500">
-                                    <i class="fas fa-check"></i>
+                                    <span aria-hidden="true" class="fas fa-check"></span>
                                 </div>
                                 <p class="ml-2 text-sm text-gray-600 dark:text-gray-300">Modular construction tools</p>
                             </li>
@@ -469,7 +469,7 @@
                     <div class="bg-white dark:bg-gray-900 rounded-xl p-6 shadow-sm hover:shadow-md transition card-hover">
                         <div class="flex items-center mb-4">
                             <div class="flex-shrink-0 h-10 w-10 rounded-full bg-purple-100 dark:bg-purple-900 flex items-center justify-center">
-                                <i class="fas fa-industry text-purple-600 dark:text-purple-400"></i>
+                                <span aria-hidden="true" class="fas fa-industry text-purple-600 dark:text-purple-400"></span>
                             </div>
                             <h3 class="ml-3 text-lg font-medium text-gray-900 dark:text-white">Industrial</h3>
                         </div>
@@ -479,19 +479,19 @@
                         <ul class="space-y-2">
                             <li class="flex items-start">
                                 <div class="flex-shrink-0 h-5 w-5 text-green-500">
-                                    <i class="fas fa-check"></i>
+                                    <span aria-hidden="true" class="fas fa-check"></span>
                                 </div>
                                 <p class="ml-2 text-sm text-gray-600 dark:text-gray-300">Structural integrity analysis</p>
                             </li>
                             <li class="flex items-start">
                                 <div class="flex-shrink-0 h-5 w-5 text-green-500">
-                                    <i class="fas fa-check"></i>
+                                    <span aria-hidden="true" class="fas fa-check"></span>
                                 </div>
                                 <p class="ml-2 text-sm text-gray-600 dark:text-gray-300">Process flow optimization</p>
                             </li>
                             <li class="flex items-start">
                                 <div class="flex-shrink-0 h-5 w-5 text-green-500">
-                                    <i class="fas fa-check"></i>
+                                    <span aria-hidden="true" class="fas fa-check"></span>
                                 </div>
                                 <p class="ml-2 text-sm text-gray-600 dark:text-gray-300">Heavy equipment integration</p>
                             </li>
@@ -593,16 +593,16 @@
                     <h3 class="text-white text-lg font-semibold mb-4">Connect</h3>
                     <div class="flex space-x-4 mb-4">
                         <a href="#" class="text-gray-400 hover:text-white transition">
-                            <i class="fab fa-twitter text-xl"></i>
+                            <span aria-hidden="true" class="fab fa-twitter text-xl"></span>
                         </a>
                         <a href="#" class="text-gray-400 hover:text-white transition">
-                            <i class="fab fa-linkedin text-xl"></i>
+                            <span aria-hidden="true" class="fab fa-linkedin text-xl"></span>
                         </a>
                         <a href="#" class="text-gray-400 hover:text-white transition">
-                            <i class="fab fa-instagram text-xl"></i>
+                            <span aria-hidden="true" class="fab fa-instagram text-xl"></span>
                         </a>
                         <a href="#" class="text-gray-400 hover:text-white transition">
-                            <i class="fab fa-youtube text-xl"></i>
+                            <span aria-hidden="true" class="fab fa-youtube text-xl"></span>
                         </a>
                     </div>
                     <p class="text-sm">
@@ -611,7 +611,7 @@
                     <div class="mt-3 flex">
                         <input type="email" placeholder="Your email" class="px-3 py-2 bg-gray-700 text-white rounded-l-md focus:outline-none focus:ring-1 focus:ring-indigo-500 w-full">
                         <button class="px-4 py-2 bg-indigo-600 text-white rounded-r-md hover:bg-indigo-700 transition">
-                            <i class="fas fa-paper-plane"></i>
+                            <span aria-hidden="true" class="fas fa-paper-plane"></span>
                         </button>
                     </div>
                 </div>
@@ -619,7 +619,7 @@
             
             <div class="border-t border-gray-700 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
                 <div class="flex items-center">
-                    <i class="fas fa-cube text-indigo-600 mr-2 text-xl" aria-hidden="true"></i>
+                    <span aria-hidden="true" class="fas fa-cube text-indigo-600 mr-2 text-xl"></span>
                     <span class="text-xl font-bold text-white">
                         ArchEng Nexus
                     </span>
@@ -668,11 +668,11 @@
         // Update theme toggle icons
         function updateThemeIcons(theme) {
             if (theme === 'dark') {
-                if (themeToggle) themeToggle.innerHTML = '<i class="fas fa-sun text-yellow-400" aria-hidden="true"></i>';
-                if (mobileThemeToggle) mobileThemeToggle.innerHTML = '<i class="fas fa-sun text-yellow-400" aria-hidden="true"></i>';
+                if (themeToggle) themeToggle.innerHTML = '<span aria-hidden="true" class="fas fa-sun text-yellow-400"></span>';
+                if (mobileThemeToggle) mobileThemeToggle.innerHTML = '<span aria-hidden="true" class="fas fa-sun text-yellow-400"></span>';
             } else {
-                if (themeToggle) themeToggle.innerHTML = '<i class="fas fa-moon text-gray-700" aria-hidden="true"></i>';
-                if (mobileThemeToggle) mobileThemeToggle.innerHTML = '<i class="fas fa-moon text-gray-700" aria-hidden="true"></i>';
+                if (themeToggle) themeToggle.innerHTML = '<span aria-hidden="true" class="fas fa-moon text-gray-700"></span>';
+                if (mobileThemeToggle) mobileThemeToggle.innerHTML = '<span aria-hidden="true" class="fas fa-moon text-gray-700"></span>';
             }
         }
         
@@ -692,9 +692,9 @@
                 
                 // Update icon
                 if (!isExpanded) {
-                    mobileMenuButton.innerHTML = '<i class="fas fa-times text-gray-700 dark:text-gray-200" aria-hidden="true"></i>';
+                    mobileMenuButton.innerHTML = '<span aria-hidden="true" class="fas fa-times text-gray-700 dark:text-gray-200"></span>';
                 } else {
-                    mobileMenuButton.innerHTML = '<i class="fas fa-bars text-gray-700 dark:text-gray-200" aria-hidden="true"></i>';
+                    mobileMenuButton.innerHTML = '<span aria-hidden="true" class="fas fa-bars text-gray-700 dark:text-gray-200"></span>';
                 }
             });
         }


### PR DESCRIPTION
## Summary
- switch FontAwesome icon tags from `<i>` to `<span aria-hidden>`
- keep JavaScript icon toggles aligned
- run `tidy -errors -q index.html`

## Testing
- `tidy -errors -q index.html | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_686dea32a69c832ca79fedac24345e96