### PR TITLE
Handle fetch failures gracefully

### DIFF
--- a/index.html
+++ b/index.html
@@ -839,6 +839,14 @@
                         solutionsList.appendChild(item);
                     });
                 }
+            })
+            .catch(err => {
+                console.error('Failed to load site-info.json', err);
+                const msg = document.createElement('p');
+                msg.className = 'text-center text-red-600 mt-4';
+                msg.textContent = 'Failed to load dynamic content. Showing default information.';
+                const main = document.querySelector('main');
+                if (main) main.prepend(msg);
             });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add a `.catch()` block to handle failures when fetching `site-info.json`
- display a user-friendly error message and log the error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686df3c77834832c84c489c8f8e10c19