### PR TITLE
Add simple Express contact API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ArchEng Nexus is a prototype landing page for a next-generation architecture and engineering platform. The site showcases features like AI automation, sustainable materials, and integrated design tools.
 
-At the bottom of the page you'll find a simple contact form. It is fully client-side, so submissions never leave the browser. Use the example server in `server.js` or your own backend to capture messages.
+At the bottom of the page you'll find a simple contact form. Submissions are sent to the example Express server in `server/index.js` where they are logged to the console.
 
 ## Running Locally
 
@@ -19,15 +19,23 @@ Then visit `http://localhost:8000` in your browser.
 
 ## Node Setup
 
-The repository does not include a Node.js application. `package.json` only defines a few optional scripts. There are no dependencies, so you can skip `npm install` or run it with the `--offline` flag if desired.
-
+Install dependencies and run the demo API server:
 
 ```bash
-npm test
+npm install
+npm start
 ```
 
-The included test checks that toggling the theme correctly updates
-`localStorage`.
+
+`npm start` launches `server/index.js` on port `3000`. Incoming contact form
+submissions will be printed to the console. Run the tests with `npm test`.
+
+## API
+
+`POST /api/contact`
+
+Send a JSON payload with `name`, `email` and `message`. The server returns
+`{ "status": "ok" }` after logging the submission.
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -457,12 +457,29 @@
         const contactForm = document.getElementById('contact-form');
         const contactSuccess = document.getElementById('contact-success');
         if (contactForm) {
-            contactForm.addEventListener('submit', function (e) {
+            contactForm.addEventListener('submit', async function (e) {
                 e.preventDefault();
-                if (contactSuccess) {
-                    contactSuccess.classList.remove('hidden');
+                const data = {
+                    name: document.getElementById('name').value,
+                    email: document.getElementById('email').value,
+                    message: document.getElementById('message').value
+                };
+                try {
+                    const res = await fetch('/api/contact', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(data)
+                    });
+                    if (res.ok) {
+                        if (contactSuccess) contactSuccess.classList.remove('hidden');
+                        contactForm.reset();
+                    } else {
+                        alert('Failed to send message.');
+                    }
+                } catch (err) {
+                    console.error('Error submitting contact form', err);
+                    alert('Failed to send message.');
                 }
-                contactForm.reset();
             });
         }
 

--- a/package.json
+++ b/package.json
@@ -2,16 +2,19 @@
   "name": "archeng-nexus",
   "version": "1.0.0",
   "description": "ArchEng Nexus is a prototype landing page for a next-generation architecture and engineering platform. The site showcases features like AI automation, sustainable materials, and integrated design tools.",
+  "type": "commonjs",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "start": "node server/index.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
   "devDependencies": {
     "jest": "^29.7.0",
     "jsdom": "^22.1.0"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
   }
-  "license": "ISC"
 }

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.json());
+
+app.post('/api/contact', (req, res) => {
+  console.log('Contact form submission:', req.body);
+  res.json({ status: 'ok' });
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- create a minimal Express server in `server/index.js`
- wire `npm start` to run the server and add Express dependency
- submit the contact form via `fetch('/api/contact')`
- document how to run the server and call the API

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e0408f640832c97b19e217b4583f1