### PR TITLE
Add Jest and API endpoint test

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,17 @@ npm start
 
 
 `npm start` launches `server/index.js` on port `3000`. Incoming contact form
-submissions will be printed to the console. Run the tests with `npm test`.
+submissions will be printed to the console.
+
+## Tests
+
+Run the automated test suite with:
+
+```bash
+npm test
+```
+
+This uses Jest to verify the contact API responds correctly.
 
 ## API
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "license": "ISC",
   "devDependencies": {
     "jest": "^29.7.0",
-    "jsdom": "^22.1.0"
+    "jsdom": "^22.1.0",
+    "supertest": "^6.3.3"
   },
   "dependencies": {
     "express": "^4.18.2"

--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,10 @@ app.post('/api/contact', (req, res) => {
   res.json({ status: 'ok' });
 });
 
-app.listen(port, () => {
-  console.log(`Server listening on port ${port}`);
-});
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}
+
+module.exports = app;

--- a/server/index.test.js
+++ b/server/index.test.js
@@ -1,0 +1,12 @@
+const request = require('supertest');
+const app = require('./index');
+
+describe('POST /api/contact', () => {
+  test('responds with status ok', async () => {
+    const res = await request(app)
+      .post('/api/contact')
+      .send({ name: 'Test', email: 'test@example.com', message: 'hi' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest with new supertest dependency
- export the Express app for testing
- add a server test for the `/api/contact` endpoint
- document running tests in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e0979c320832cbb279def6f2fd2e0