### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy static site
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm test
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ submissions will be printed to the console. Run the tests with `npm test`.
 Send a JSON payload with `name`, `email` and `message`. The server returns
 `{ "status": "ok" }` after logging the submission.
 
+## Deployment
+
+This repository includes a GitHub Actions workflow that deploys the static site
+to **GitHub Pages**. To enable it for your fork:
+
+1. Open your repository's **Settings** and navigate to **Pages**.
+2. Under **Build and deployment**, select **GitHub Actions** as the source and
+   save.
+
+On every push to the `main` branch the workflow runs the tests and publishes the
+site. Once the workflow completes, visit:
+
+```
+https://<your-user>.github.io/archeng-nexus/
+```
+
+Replace `<your-user>` with your GitHub username to see the deployed site.
+
 ## License
 
 This project is released under the MIT License.


### PR DESCRIPTION
## Summary
- add workflow to deploy static site with GitHub Actions
- document how to enable and view the deployment

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686e0988a0f4832caa7bf19e38e5635f