### PR TITLE
Update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Then replace the CDN `<script>` with a link to the generated CSS file.
 
 ## Node Setup
 
-Install dependencies and run the demo API server:
+Install dependencies and start the demo Express server that handles contact form submissions:
 
 ```bash
 npm install
@@ -43,8 +43,9 @@ npm start
 ```
 
 
-`npm start` launches `server/index.js` on port `3000`. Incoming contact form
-submissions will be printed to the console.
+`npm start` launches `server/index.js` on port `3000`. Leave this process
+running while you test the site. Every time the contact form is submitted the
+details will be printed in this terminal window.
 
 ## Tests
 
@@ -80,6 +81,11 @@ https://<your-user>.github.io/archeng-nexus/
 ```
 
 Replace `<your-user>` with your GitHub username to see the deployed site.
+
+GitHub Pages hosts only the static files under `index.html` and `scripts/`. The
+Express API server started with `npm start` is **not** deployed there. If you
+deploy to Pages without running your own server the contact form will appear but
+submissions will fail because the backend is missing.
 
 ## License
 


### PR DESCRIPTION
## Summary
- clarify launching the Express server with `npm start`
- explain that submissions are logged to the console
- add note that GitHub Pages deployment does not include the API backend

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e202b7930832ca12e5b234f6b1022