### PR TITLE
Configure CORS origins via env var

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -4,7 +4,12 @@ const path = require('path');
 const app = express();
 const port = process.env.PORT || 3000;
 
-app.use(cors());
+// Read allowed origins from environment variable
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(',').map((o) => o.trim()).filter(Boolean)
+  : [];
+
+app.use(cors({ origin: allowedOrigins }));
 app.use(express.json());
 app.use(express.static(path.join(__dirname, '..')));
 

--- a/server/index.test.js
+++ b/server/index.test.js
@@ -1,4 +1,7 @@
 const request = require('supertest');
+
+// Configure allowed origins for tests
+process.env.ALLOWED_ORIGINS = 'http://allowed.com';
 const app = require('./index');
 
 describe('POST /api/contact', () => {
@@ -13,7 +16,12 @@ describe('POST /api/contact', () => {
   test('includes CORS headers', async () => {
     const res = await request(app)
       .post('/api/contact')
+      .set('Origin', 'http://allowed.com')
       .send({ name: 'Test', email: 'test@example.com', message: 'hi' });
-    expect(res.headers['access-control-allow-origin']).toBe('*');
+    expect(res.headers['access-control-allow-origin']).toBe('http://allowed.com');
+  });
+
+  afterAll(() => {
+    delete process.env.ALLOWED_ORIGINS;
   });
 });


### PR DESCRIPTION
## Summary
- limit allowed CORS origins in the server by reading the `ALLOWED_ORIGINS` env var
- update tests to use the new origin setting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e2a60f310832ca0314a56848bd31f