### PR TITLE
Add contact form validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^4.18.2"
+        "cors": "^2.8.5",
+        "express": "^4.18.2",
+        "express-validator": "^6.15.0"
       },
       "devDependencies": {
         "jest": "^29.7.0",
@@ -1739,6 +1741,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -2187,6 +2202,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-validator": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.15.0.tgz",
+      "integrity": "sha512-r05VYoBL3i2pswuehoFSy+uM8NBuVaY7avp5qrYjQBDzagx2Z5A77FZqPT8/gNLF3HopWkIzaTFaC4JysWXLqg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "^13.9.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3627,6 +3655,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3854,6 +3888,15 @@
       "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -4987,6 +5030,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.15",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "express-validator": "^6.15.0"
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const path = require('path');
+const { body, validationResult } = require('express-validator');
 const app = express();
 const port = process.env.PORT || 3000;
 
@@ -8,10 +9,27 @@ app.use(cors());
 app.use(express.json());
 app.use(express.static(path.join(__dirname, '..')));
 
-app.post('/api/contact', (req, res) => {
-  console.log('Contact form submission:', req.body);
-  res.json({ status: 'ok' });
-});
+app.post(
+  '/api/contact',
+  [
+    body('name').trim().notEmpty().escape(),
+    body('email').isEmail().normalizeEmail(),
+    body('message').trim().notEmpty().escape(),
+  ],
+  (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const sanitized = {
+      name: req.body.name,
+      email: req.body.email,
+      message: req.body.message,
+    };
+    console.log('Contact form submission:', sanitized);
+    res.json({ status: 'ok' });
+  }
+);
 
 if (require.main === module) {
   app.listen(port, () => {

--- a/server/index.test.js
+++ b/server/index.test.js
@@ -16,4 +16,28 @@ describe('POST /api/contact', () => {
       .send({ name: 'Test', email: 'test@example.com', message: 'hi' });
     expect(res.headers['access-control-allow-origin']).toBe('*');
   });
+
+  test('rejects invalid email', async () => {
+    const res = await request(app)
+      .post('/api/contact')
+      .send({ name: 'Test', email: 'invalid', message: 'hi' });
+    expect(res.statusCode).toBe(400);
+    expect(res.body.errors).toBeDefined();
+  });
+
+  test('rejects missing name', async () => {
+    const res = await request(app)
+      .post('/api/contact')
+      .send({ email: 'test@example.com', message: 'hi' });
+    expect(res.statusCode).toBe(400);
+    expect(res.body.errors).toBeDefined();
+  });
+
+  test('rejects empty message', async () => {
+    const res = await request(app)
+      .post('/api/contact')
+      .send({ name: 'Test', email: 'test@example.com', message: '' });
+    expect(res.statusCode).toBe(400);
+    expect(res.body.errors).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary
- validate contact form fields with `express-validator`
- sanitize input before logging
- add express-validator dependency
- test validation failure scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686e2a6416e8832c909d13b79ce17c2e